### PR TITLE
remove gcc warnings on Ubuntu

### DIFF
--- a/mcxt.c
+++ b/mcxt.c
@@ -1,9 +1,5 @@
 #include "mcxt.h"
 
-extern int vsnprintf(char *__restrict __s, size_t __maxlen,
-                     const char *__restrict __format, _G_va_list __arg)
-    __attribute__((__format__(gnu_printf, 3, 0)));
-
 static MemoryContext GetMemoryChunkContext(void *pointer);
 static int AllocSetFreeIndex(Size size);
 static int appendStringInfoVA(StringInfo str, const char *fmt, va_list args);

--- a/test.c
+++ b/test.c
@@ -121,7 +121,7 @@ void MemTest(void)
                       ";lkj;lfkj;lkj;lkj(*YUokjasd;lkjf;2o3iu4;lkja;lkjf;alkj"
                       ";lkdjf;l23i4j1;l23kj;lksjdf;lkj(*&POIjf;alksjdf;lkj3;4l"
                       "k5j1;lkj4;l1k23javs90d8ufsldkjfasdfasdf",
-              3 * 1024);
+              3070);
 
        printf("%s\n", array);
        printf("%s\n\n", array1);
@@ -216,7 +216,7 @@ void MemTest(void)
                       ";lkj;lfkj;lkj;lkj(*YUokjasd;lkjf;2o3iu4;lkja;lkjf;alkj"
                       ";lkdjf;l23i4j1;l23kj;lksjdf;lkj(*&POIjf;alksjdf;lkj3;4l"
                       "k5j1;lkj4;l1k23javs90d8ufsldkjfasdfasdf",
-              4 * 1024);
+              4092);
 
        printf("%s\n\n", array1);
 


### PR DESCRIPTION
remove some unsafe code that may cause warnings on Ubuntu.